### PR TITLE
Fixing LocalCommand scoping issue.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
 # Vagrant
 .vagrant
 .cache

--- a/test/centos7-salt/Dockerfile
+++ b/test/centos7-salt/Dockerfile
@@ -1,6 +1,6 @@
 FROM milcom/centos7-systemd
 # Copy repo inserted by Vagrant into our image, so we can install salt-minion.
-COPY repo-saltstack-el7.repo /etc/yum.repos.d/
+COPY saltstack.repo /etc/yum.repos.d/
 # Netstat is used by testinfra
 RUN yum install -y epel-release initscripts salt-minion sudo net-tools; yum clean all
 COPY minion /etc/salt/

--- a/test/centos7-salt/repo-saltstack-el7.repo
+++ b/test/centos7-salt/repo-saltstack-el7.repo
@@ -1,8 +1,0 @@
-[repo-saltstack-el7]
-name=SaltStack EL7 Repo
-baseurl=https://repo.saltstack.com/yum/rhel7/
-skip_if_unavailable=True
-gpgcheck=1
-gpgkey=https://repo.saltstack.com/yum/rhel7/SALTSTACK-GPG-KEY.pub
-enabled=1
-enabled_metadata=1

--- a/test/centos7-salt/saltstack.repo
+++ b/test/centos7-salt/saltstack.repo
@@ -1,0 +1,7 @@
+[saltstack-repo]
+name=SaltStack repo for Red Hat Enterprise Linux $releasever
+baseurl=https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest
+enabled=1
+gpgcheck=1
+gpgkey=https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest/SALTSTACK-GPG-KEY.pub
+       https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest/base/RPM-GPG-KEY-CentOS-7

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |config|
   end
 
   #
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/xenial64"
   config.vm.hostname = "salt-dev"
 
   ## For masterless, mount your salt file root


### PR DESCRIPTION
It appears testinfra has changed since you first worked on this repo.
As such, testinfra -v didn't work as expected. This was due to scoping
issues with LocalCommand, and testinfra.backend.docker no longer exists
as a directly accessible attribute (you need to use get_backend_class
instead).

I've updated things so that they should run for most people off the bat.

Fixes #1 

References:
https://docs.saltstack.com/en/latest/topics/installation/rhel.html (CentOS)
https://github.com/infOpen/pytest-ansible-docker/blob/master/pytest_ansible_docker.py#L16
https://github.com/splksusqa/tsplk-formula/blob/1145717f414ca78c936313f95db77cb9b9c0e4c0/test/conftest.py#L82